### PR TITLE
Database maintenance additions

### DIFF
--- a/data_tracking/database_maintenance.sql
+++ b/data_tracking/database_maintenance.sql
@@ -64,3 +64,6 @@ DELETE FROM Track WHERE track.track_name = "2d5d297545c80e0d5e714c8e8b0d0aa6e3db
 
 
 COMMIT;
+
+DROP VIEW IF EXISTS room_sizes;
+VACUUM; /*Shrink Database, necessary to keep Database minimal size, especially if the scripts in the migration folder just ran (and doubled the DB size)*/


### PR DESCRIPTION
Migrations cause DB size to balloon (roughly double). SQLite does not shrink automatically, so we need to vaccuum it so it does. Also drop the view as well since it doesn't seem needed anymore.